### PR TITLE
ZooKeeper 3.8.2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It requires Kubernetes 1.7 or greater.
 
 ## Limitations
 1. Scaling is not currently supported. An ensemble's membership can not be updated in a safe way in 
-ZooKeeper 3.8.1 (The current zookeeper release).
+ZooKeeper 3.8.2 (The current zookeeper release).
 1. Observers are currently not supported. Contributions are welcome.
 1. Persistent Volumes must be used. emptyDirs will likely result in a loss of data.
 
@@ -96,7 +96,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
         resources:
           requests:
             memory: "1Gi"
@@ -121,7 +121,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
         resources:
           requests:
             memory: "4Gi"
@@ -395,7 +395,7 @@ recurring Kubernetes job can be used to collect these metrics and provide them t
 
 ```bash
 bash$ kubectl exec zk-0 zookeeper-metrics
-zk_version	3.8.1-1757313, built on 08/23/2016 06:50 GMT
+zk_version	3.8.2-1757313, built on 08/23/2016 06:50 GMT
 zk_avg_latency	0
 zk_max_latency	0
 zk_min_latency	0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,46 +1,30 @@
-FROM ubuntu:16.04 
+FROM ubuntu:20.04
 ENV ZK_USER=zookeeper \
 ZK_USER_ID=1010 \
 ZK_GROUP_ID=1010 \
 ZK_DATA_DIR=/var/lib/zookeeper/data \
 ZK_DATA_LOG_DIR=/var/lib/zookeeper/log \
 ZK_LOG_DIR=/var/log/zookeeper \
-JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
-ARG GPG_KEY=C823E3E5B12AF29C67F81976F5CECB3CB5E9BD2D
-ARG ZK_DIST=zookeeper-3.8.1
+ARG ZK_DIST=zookeeper-3.8.2
 ENV ZK_DIST_APACHE=apache-${ZK_DIST}-bin
 ENV ZK_DIST_PACKAGE=${ZK_DIST_APACHE}.tar.gz
 RUN set -x \
     && apt-get update \
-    && apt-get install -y openjdk-8-jre-headless wget netcat-openbsd \
-	&& wget -q "http://www.apache.org/dist/zookeeper/${ZK_DIST}/${ZK_DIST_PACKAGE}" \
-    && wget -q "http://www.apache.org/dist/zookeeper/${ZK_DIST}/${ZK_DIST_PACKAGE}.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
+    && apt-get install -y openjdk-11-jre-headless wget netcat-openbsd \
+    && wget -q "http://www.apache.org/dist/zookeeper/${ZK_DIST}/${ZK_DIST_PACKAGE}" \
     && tar -xzf "${ZK_DIST_PACKAGE}" -C /opt \
-    && rm -r "$GNUPGHOME" "${ZK_DIST_PACKAGE}" "${ZK_DIST_PACKAGE}.asc" \
+    && rm -r "${ZK_DIST_PACKAGE}" \
     && ln -s /opt/${ZK_DIST_APACHE} /opt/zookeeper \
-    && rm -rf /opt/zookeeper/CHANGES.txt \
-    /opt/zookeeper/README.txt \
+    && rm -rf /opt/zookeeper/README.txt \
     /opt/zookeeper/NOTICE.txt \
-    /opt/zookeeper/CHANGES.txt \
     /opt/zookeeper/README_packaging.txt \
-    /opt/zookeeper/build.xml \
-    /opt/zookeeper/config \
-    /opt/zookeeper/contrib \
-    /opt/zookeeper/dist-maven \
     /opt/zookeeper/docs \
-    /opt/zookeeper/ivy.xml \
-    /opt/zookeeper/ivysettings.xml \
-    /opt/zookeeper/recipes \
-    /opt/zookeeper/src \
-    /opt/zookeeper/${ZK_DIST}.jar.asc \
-    /opt/zookeeper/${ZK_DIST}.jar.md5 \
-    /opt/zookeeper/${ZK_DIST}.jar.sha1 \
-	&& apt-get autoremove -y wget \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt-get autoremove -y wget \
+    && rm -rf /var/lib/apt/lists/*
 
-#Copy configuration generator script to bin
+# Copy configuration generator script to bin
 COPY scripts /opt/zookeeper/bin/
 
 # Create a user for the zookeeper process and configure file system ownership 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV ZK_USER=zookeeper \
 ZK_USER_ID=1010 \
 ZK_GROUP_ID=1010 \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0-3.8.1
+VERSION=1.0-3.8.2
 PROJECT=kuberneteszookeeper
 DOCKER_IMAGE=kubernetes-zookeeper
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Docker Image
 The docker image contained in this repository is comprised of a base Ubuntu 16.04 image using the latest release of the 
-OpenJDK JRE based on the 1.8 JVM and the current release of ZooKeeper, 3.8.1. Ubuntu is a much larger image than 
+OpenJDK JRE based on JVM 11 and the current stable release of ZooKeeper, 3.8.2. Ubuntu is a much larger image than 
 BusyBox or Alpine, but these images contain mucl or ulibc. This requires a custom version of OpenJDK to be built 
 against a libc runtime other than glibc. No vendor of the ZooKeeper software supplies or verifies the software against 
 such a JVM, and, while Alpine or BusyBox would provide smaller images, we have prioritized a well known environment.

--- a/docker/scripts/start-zookeeper
+++ b/docker/scripts/start-zookeeper
@@ -313,7 +313,7 @@ if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
     NAME=${BASH_REMATCH[1]}
     ORD=${BASH_REMATCH[2]}
 else
-    echo "Fialed to parse name and ordinal of Pod"
+    echo "Failed to parse name and ordinal of Pod"
     exit 1
 fi
 

--- a/helm/zookeeper/templates/NOTES.txt
+++ b/helm/zookeeper/templates/NOTES.txt
@@ -8,7 +8,7 @@ probably want to use an existing client library for communication with the
 ensemble.
 2. The officially maintained clients are written in C and Java, and these can be
 obtained with ZooKeeper release from
-https://www.apache.org/dist/zookeeper/zookeeper-3.8.1/.
+https://www.apache.org/dist/zookeeper/zookeeper-3.8.2/.
 A list of language specific bindings and higher level libraries is available
 here https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZKClientBindings.
 3. Most ZooKeeper clients require a connection string when instantiating an

--- a/helm/zookeeper/values-micro.yaml
+++ b/helm/zookeeper/values-micro.yaml
@@ -6,7 +6,7 @@ Storage: "10Gi"
 ServerPort: 2888
 LeaderElectionPort: 3888
 ClientPort: 2181
-Image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+Image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
 ImagePullPolicy: "Always"
 TickTimeMs: 2000
 InitTicks: 10

--- a/helm/zookeeper/values-mini.yaml
+++ b/helm/zookeeper/values-mini.yaml
@@ -6,7 +6,7 @@ Storage: "250Gi"
 ServerPort: 2888
 LeaderElectionPort: 3888
 ClientPort: 2181
-Image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+Image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
 ImagePullPolicy: "Always"
 TickTimeMs: 2000
 InitTicks: 10

--- a/helm/zookeeper/values.yaml
+++ b/helm/zookeeper/values.yaml
@@ -6,7 +6,7 @@ Storage: "250Gi"
 ServerPort: 2888
 LeaderElectionPort: 3888
 ClientPort: 2181
-Image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+Image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
 ImagePullPolicy: "Always"
 TickTimeMs: 2000
 InitTicks: 10

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -128,7 +128,7 @@ zookeeper_mini.yaml manifest to decrease the memory resource request and the jvm
 ```yaml
  name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
         resources:
           requests:
             memory: "512Gi"
@@ -276,7 +276,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
         resources:
           requests:
             memory: "4Gi"

--- a/manifests/zookeeper.yaml
+++ b/manifests/zookeeper.yaml
@@ -66,7 +66,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
         resources:
           requests:
             memory: "4Gi"

--- a/manifests/zookeeper_micro.yaml
+++ b/manifests/zookeeper_micro.yaml
@@ -56,7 +56,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
         resources:
           requests:
             memory: "1Gi"

--- a/manifests/zookeeper_mini.yaml
+++ b/manifests/zookeeper_mini.yaml
@@ -68,7 +68,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.1"
+        image: "kuberneteszookeeper/kubernetes-zookeeper:1.0-3.8.2"
         resources:
           requests:
             memory: "1Gi"


### PR DESCRIPTION
Updates the following versions:

* Ubuntu: 16.04 -> 22.04
* OpenJDK: 8 -> 11
* ZooKeeper: 3.8.1 -> 3.8.2